### PR TITLE
Version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@
 ## [1.0.0][] - 2023-11-00
 
 - Release version
+-->
 
-## [0.9.0][] - 2023-11-00
+<!-- ## [0.9.0][] - 2023-11-10
 
 - Pre-release fixes
 - Documentation enhancements
-- Code quality improvements
- -->
+- Code quality improvements -->
 
-## [0.8.0][] - 2023-11-09
+## [0.8.0][] - 2023-11-08
 
 - JSDOC generation for metatype module, [issue](https://github.com/astrohelm/metaforge/issues/11)
 - Metatest optional default export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,31 @@
 
 ## [Unreleased][unreleased]
 
+## [0.8.0][] - 2023-11-09
+
+- JSDOC generation for metatype module, [issue](https://github.com/astrohelm/metaforge/issues/11)
+- Metatest optional default export
+- Typings improvements
+
 ## [0.7.0][] - 2023-11-08
 
-- Calculated fields **[experemental]**
+- Calculated fields **[experemental]**, [issue](https://github.com/astrohelm/metaforge/issues/21)
 - Readme & tests for module
 - Fixed README example errors
 
 ## [0.6.0][] - 2023-11-06
 
-- Typescript generation module
+- Typescript generation module, [issue](https://github.com/astrohelm/metaforge/issues/5)
 - Documentation fixes
 
 ## [0.5.0][] - 2023-11-05
 
-- Readme enhancement
+- Readme enhancement, [issue](https://github.com/astrohelm/metaforge/issues/11)
 - JSDOC documentation
 
 ## [0.4.0][] - 2023-11-05
+
+[Modular mechanism issue](https://github.com/astrohelm/metaforge/issues/17)
 
 - Support latest:21 node version
 - Removed parser (maybe temporary)
@@ -93,7 +101,8 @@
 - Default exotic types: Any, Undefined, JSON
 - Custom Errors
 
-[unreleased]: https://github.com/astrohelm/metaforge/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/astrohelm/metaforge/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/astrohelm/metaforge/compare/v0.6.0...v0.7.0
 [0.7.0]: https://github.com/astrohelm/metaforge/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/astrohelm/metaforge/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/astrohelm/metaforge/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased][unreleased]
 
+<!--
+## [1.0.0][] - 2023-11-00
+
+- Release version
+
+## [0.9.0][] - 2023-11-00
+
+- Pre-release fixes
+- Documentation enhancements
+- Code quality improvements
+ -->
+
 ## [0.8.0][] - 2023-11-09
 
 - JSDOC generation for metatype module, [issue](https://github.com/astrohelm/metaforge/issues/11)
@@ -102,7 +114,9 @@
 - Custom Errors
 
 [unreleased]: https://github.com/astrohelm/metaforge/compare/v0.8.0...HEAD
-[0.8.0]: https://github.com/astrohelm/metaforge/compare/v0.6.0...v0.7.0
+[1.0.0]: https://github.com/astrohelm/metaforge/compare/v1.0.0...v1.0.0
+[0.9.0]: https://github.com/astrohelm/metaforge/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/astrohelm/metaforge/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/astrohelm/metaforge/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/astrohelm/metaforge/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/astrohelm/metaforge/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const userSchema = new Schema({
   $meta: { name: 'user', description: 'schema for users testing' },
   phone: { $type: 'union', types: ['number', 'string'] }, //? number or string
   name: { $type: 'set', items: ['string', '?string'] }, //? set tuple
-  prase: (sample, parent, root) => 'Hello ' + [...parent.name].join(' ') + ' !', // Calculated fields
+  phrase: (sample, parent, root) => 'Hello ' + [...parent.name].join(' ') + ' !', // Calculated fields
   mask: { $type: 'array', items: 'string' }, //? array
   ip: {
     $type: 'array',
@@ -31,6 +31,7 @@ const userSchema = new Schema({
     items: { $type: 'union', types: ['string', '?number'], condition: 'oneof', $required: false },
   },
   type: ['elite', 'member', 'guest'], //? enum
+  '/[a-Z]+Id/': { $type: '?number', isPattern: true }, // pattern fields
   address: 'string',
   secondAddress: '?string',
   options: { notifications: 'boolean', lvls: ['number', 'string'] },
@@ -40,6 +41,7 @@ const systemSchema = new Schema({ $type: 'array', items: userSchema });
 
 const sample = [
   {
+    myId: 1,
     phone: '7(***)...',
     ip: ['192', 168, '1', null],
     type: 'elite',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">MetaForge v0.7.0 🕵️</h1>
+<h1 align="center">MetaForge v0.8.0 🕵️</h1>
 
 ## Describe your data structures by subset of JavaScript and:
 

--- a/lib/forge.js
+++ b/lib/forge.js
@@ -22,7 +22,10 @@ module.exports = function Forge(schema, custom = {}) {
       const meta = plan.$meta;
       if (plan.$id) this.$id = plan.$id;
       [this.$required, this.$type] = [plan.$required ?? true, name];
-      if (meta && typeof meta === 'object' && !Array.isArray(meta)) Object.assign(this, meta);
+      if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+        this.$meta = meta;
+        Object.assign(this, meta);
+      }
       [...before, ...chain, ...after].forEach(proto => proto.call(this, plan, schema.tools));
       if (!this.$kind) this.$kind = 'unknown';
     };

--- a/modules/handyman/repairkit.js
+++ b/modules/handyman/repairkit.js
@@ -46,7 +46,7 @@ module.exports = function RepairKit(schema, namespace) {
 
   function object(plan, warn) {
     if (typeof plan.$calc === 'function') return func(plan, warn);
-    const { $required = true, $meta, $id, ...fields } = plan; //? Schema wrapper #2
+    const { $required = true, $id, ...fields } = plan; //? Schema wrapper #2
     if (plan.constructor.name === 'Schema') return { $type: 'schema', schema: plan, $required };
     if (!plan || plan.constructor.name !== 'Object') return unknown;
     if ($id) return { $type: 'schema', $id, schema: child(fields), $required };
@@ -55,7 +55,8 @@ module.exports = function RepairKit(schema, namespace) {
       warn({ cause: TYPE_NOT_FOUND + plan.$type, sample: plan.$type, plan });
       return unknown;
     }
-    const result = { $type: 'object', properties: { ...fields }, $required };
+    const { $meta, ...other } = fields;
+    const result = { $type: 'object', properties: { ...other }, $required };
     if ($meta) result.$meta = $meta;
     return result;
   }

--- a/modules/types/index.js
+++ b/modules/types/index.js
@@ -11,8 +11,11 @@ module.exports = schema => {
     this.toTypescript = (name, namespace) => compile(nameFix(name), namespace);
   });
 
+  // TODO: Default export removable
+  // TODO: JSDOC documentation
   schema.dts = (name = 'MetaForge', options = {}) => {
     const mode = options.mode ?? 'mjs';
+    // const defaultExport = options.defaultExport ?? true;
     if (name !== nameFix(name)) throw new Error('Invalid name format');
     const namespace = { definitions: new Set(), exports: new Set() };
     const type = schema.toTypescript(name, namespace);

--- a/modules/types/index.test.js
+++ b/modules/types/index.test.js
@@ -5,67 +5,66 @@ const [test, assert] = [require('node:test'), require('node:assert')];
 const Schema = require('../../');
 
 const generate = (type, name) => new Schema(type).dts(name);
-const base = 'type MetaForge=';
-const exp = 'export type{MetaForge};export default MetaForge;';
+const base = 'type MetaForge = ';
+const exp = '\nexport type { MetaForge };\nexport default MetaForge;';
 test('[DTS] Basic', () => {
   assert.strictEqual(generate({ $type: 'string' }), base + 'string;' + exp);
   assert.strictEqual(generate('number'), base + 'number;' + exp);
   assert.strictEqual(generate('bigint'), base + 'bigint;' + exp);
   assert.strictEqual(generate('boolean'), base + 'boolean;' + exp);
   assert.strictEqual(generate('unknown'), base + 'unknown;' + exp);
-  assert.strictEqual(generate('?any'), base + '(any|null|undefined);' + exp);
+  assert.strictEqual(generate('?any'), base + '(any|undefined);' + exp);
 });
 
 test('[DTS] Enumerable', () => {
   assert.strictEqual(generate(['hello', 'world']), base + "('hello'|'world');" + exp);
   const data = ['hello', 'there', 'my', 'dear', 'world'];
-  const result = `type MetaForge='hello'|'there'|'my'|'dear'|'world';`;
+  const result = `type MetaForge = 'hello'|'there'|'my'|'dear'|'world';`;
   assert.strictEqual(generate(data), result + exp);
 });
 
 test('[DTS] Union', () => {
   assert.strictEqual(
     generate({ $type: 'union', types: ['string', '?number'] }),
-    'type MetaForge=(string|(number|null|undefined));' + exp,
+    'type MetaForge = (string|(number|undefined));' + exp,
   );
   assert.strictEqual(
     generate({ $type: 'union', types: [{ $type: 'union', types: ['string', '?number'] }] }),
-    'type MetaForge=((string|(number|null|undefined)));' + exp,
+    'type MetaForge = ((string|(number|undefined)));' + exp,
   );
 });
 
 test('[DTS] Array', () => {
   assert.strictEqual(
     generate(['string', '?number']),
-    'type MetaForge=[string,(number|null|undefined)];' + exp,
+    'type MetaForge = [string,(number|undefined)];' + exp,
   );
   assert.strictEqual(
     generate({ $type: 'set', items: ['string', '?number'] }),
-    'type MetaForge=Set<string|(number|null|undefined)>;' + exp,
+    'type MetaForge = Set<string|(number|undefined)>;' + exp,
   );
   assert.strictEqual(
     generate({ $type: 'array', items: { $type: 'union', types: ['string', '?number'] } }),
-    'type MetaForge=((string|(number|null|undefined)))[];' + exp,
+    'type MetaForge = ((string|(number|undefined)))[];' + exp,
   );
   assert.strictEqual(
     generate({ $type: 'tuple', items: { $type: 'union', types: ['string', '?number'] } }),
-    'type MetaForge=[(string|(number|null|undefined))];' + exp,
+    'type MetaForge = [(string|(number|undefined))];' + exp,
   );
   const enumerable = ['hello', 'there', 'my', 'dear', 'world'];
   const complex = ['?number', enumerable, { a: 'string', b: enumerable }];
-  let result = "type MetaForge_1='hello'|'there'|'my'|'dear'|'world';";
-  result += "type MetaForge_2_b='hello'|'there'|'my'|'dear'|'world';";
-  result += 'interface MetaForge_2{a:string;b:MetaForge_2_b;};';
-  result += 'type MetaForge=[(number|null|undefined),MetaForge_1,MetaForge_2];' + exp;
+  let result = "type MetaForge_1 = 'hello'|'there'|'my'|'dear'|'world';\n\n";
+  result += "type MetaForge_2_b = 'hello'|'there'|'my'|'dear'|'world';\n\n";
+  result += 'interface MetaForge_2 {\n  a: string;\n  b: MetaForge_2_b;\n};\n\n';
+  result += 'type MetaForge = [(number|undefined),MetaForge_1,MetaForge_2];' + exp;
   assert.strictEqual(generate(complex), result);
 });
 
 test('[DTS] Struct', () => {
   const schema = { "'": 'string', '"': 'string', b: '?number', 'c+': { d: ['hello', 'world'] } };
-  let result = "interface MetaForge_c{d:('hello'|'world');};";
-  result += 'interface MetaForge{"\'":string;\'"\':string;';
-  result += "b?:(number|null|undefined);'c+':MetaForge_c;};";
-  result += exp;
+  let result = "interface MetaForge_c {\n  d: ('hello'|'world');\n};\n\n";
+  result += 'interface MetaForge {\n  "\'": string;\n  \'"\': string;';
+  result += "\n  b?: (number|undefined);\n  'c+': MetaForge_c;\n};" + exp;
   assert.strictEqual(generate(schema), result);
 });
 
@@ -78,18 +77,25 @@ test('[DTS] Schema', () => {
     d: { $type: 'schema', schema: new Schema('number'), $id: 'MySubSchema2' },
     e: { $type: 'schema', schema: new Schema({ $type: 'number', $id: 'MySubSchema3' }) },
   };
-  let r = 'interface MySubSchema{c:number;};type MySubSchema2=number;type MySubSchema3=number;';
-  r += `interface MetaForge{a:string;b:MySubSchema;c?:(string|null|undefined);`;
-  r += 'd:MySubSchema2;e:MySubSchema3;};';
-  r += 'export type{MySubSchema,MySubSchema2,MySubSchema3,MetaForge};export default MetaForge;';
+  let r = 'interface MySubSchema {\n  c: number;\n};\n\ntype MySubSchema2 = number;\n\n';
+  r += `type MySubSchema3 = number;\n\n`;
+  r += 'interface MetaForge {\n  a: string;\n  b: MySubSchema;';
+  r += `\n  c?: (string|undefined);\n  d: MySubSchema2;\n  e: MySubSchema3;\n};\n`;
+  r += 'export type { MySubSchema, MySubSchema2, MySubSchema3, MetaForge };';
+  r += '\nexport default MetaForge;';
   assert.strictEqual(generate(schema), r);
 });
 
-test('[DTS] Modes', () => {
-  const schema = new Schema({ a: { $id: 'MySubSchema', c: 'number' } });
-  const result = 'interface MySubSchema{c:number;};interface MetaForge{a:MySubSchema;};';
-  const mjs = result + 'export type{MySubSchema,MetaForge};export default MetaForge;';
-  const cjs = result + 'export = MetaForge;';
-  assert.strictEqual(schema.dts('MetaForge'), mjs);
-  assert.strictEqual(schema.dts('MetaForge', { mode: 'cjs' }), cjs);
+test('[DTS] JSDoc', () => {
+  const schema = new Schema({
+    $id: 'User',
+    $meta: { '@name': 'user', '@description': 'About user' },
+    name: { $type: 'string', $meta: { '@description': 'User name' } },
+    age: '?number',
+  });
+  let result = '/**\n * @name user\n * @description About user\n */\n';
+  result += 'interface MetaForge {\n  /**\n   * @description User name\n   */\n';
+  result += '  name: string;\n  age?: (number|undefined);\n};\n\n';
+  result += 'export type { MetaForge };\nexport default MetaForge;';
+  assert.strictEqual(schema.dts(), result);
 });

--- a/modules/types/utils.js
+++ b/modules/types/utils.js
@@ -15,4 +15,13 @@ const brackets = (sample, allowSkip) => {
   return sep + sample + sep;
 };
 
-module.exports = { nameFix, brackets, MAX_ITEMS };
+const jsdoc = (meta, spacing = '') => {
+  let result = spacing + '/**\n';
+  for (const key in meta) {
+    if (key[0] !== '@') continue;
+    result += spacing + ` * ${key} ${meta[key]}\n`;
+  }
+  return result + spacing + ' */\n';
+};
+
+module.exports = { nameFix, brackets, MAX_ITEMS, jsdoc };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metaforge",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metaforge",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "astropack": "^0.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "commonjs",
   "name": "metaforge",
   "homepage": "https://astrohelm.ru",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "node": ">= 18"
   },
   "browser": {},
-  "files": ["/lib", "/types"],
+  "files": [
+    "/lib",
+    "/types"
+  ],
   "scripts": {
     "test": "node --test",
     "dev": "node index.js",

--- a/tests/custom.test.js
+++ b/tests/custom.test.js
@@ -48,12 +48,13 @@ test('Custom modules', () => {
 test('Example test', () => {
   const userSchema = new Schema({
     $id: 'userSchema',
-    $meta: { name: 'user', description: 'schema for users testing' },
+    $meta: { '@name': 'user', '@description': 'schema for users testing' },
     phone: { $type: 'union', types: ['number', 'string'] }, //? number or string
     name: { $type: 'set', items: ['string', '?string'] }, //? set tuple
     phrase: (_, parent) => 'Hello ' + [...parent.name].join(' ') + ' !',
     mask: { $type: 'array', items: 'string' }, //? array
     ip: {
+      $meta: { '@description': 'User ip adress' },
       $type: 'array',
       $required: false,
       $rules: [ip => ip[0] === '192'], //? custom rules
@@ -66,7 +67,11 @@ test('Example test', () => {
     options: { notifications: 'boolean', lvls: ['number', 'string'] },
   });
 
-  const systemSchema = new Schema({ $type: 'array', items: userSchema });
+  const systemSchema = new Schema({
+    $meta: { '@name': 'Users', '@description': 'Array of users' },
+    $type: 'array',
+    items: userSchema,
+  });
 
   const sample = [
     {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,11 +84,16 @@ class ForgePrototype {
    * @description Generates type declaration file for schema
    * @example
    * const schema = new Schema('string').dts('MyType');
-   * // type MyType = (unknown | null | undefined);
+   * // type MyType = (unknown | undefined);
    * // export type { MyType };
    * // export default MyType;
    */
-  dts?: (name?: string, options?: { mode?: 'cjs' | 'mjs' }) => string;
+  dts?: (
+    name?: string,
+    options?: {
+      export: { mode?: 'cjs' | 'mjs'; type: 'all' | 'no' | 'exports-only' | 'default-only' };
+    },
+  ) => string;
   /**
    * Handyman module required
    * @description Calculated fields

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,12 +65,45 @@ class ForgePrototype {
   $type: string;
   $required: boolean;
   $plan: Plan;
+  /**
+   * Metatest module required
+   * @description Test any sample for compatibility
+   * @example
+   * const schema = new Schema('string');
+   * schema.test('Hello world').valid // true
+   * schema.test(123) // [SchemaError {}]
+   * schema.test(123).valid // false
+   */
   test?: (
     sample: unknown,
     root?: string,
     partial?: boolean,
   ) => Array<SchemaError> & { valid: boolean };
+  /**
+   * Metatest module required
+   * @description Generates type declaration file for schema
+   * @example
+   * const schema = new Schema('string').dts('MyType');
+   * // type MyType = (unknown | null | undefined);
+   * // export type { MyType };
+   * // export default MyType;
+   */
   dts?: (name?: string, options?: { mode?: 'cjs' | 'mjs' }) => string;
+  /**
+   * Handyman module required
+   * @description Calculated fields
+   * @example
+   * const example = { name: 'Alexander' };
+   * const schema = { name: 'string', phrase: (_, parent) => 'Hello ' + parent.name }
+   * new Schema(schema).calculate(example, true); // { name: 'Alexander', phrase: 'Hello Alexander' }
+   * example; // Not assigned to sample object { name: 'Alexander' };
+   * new Schema(schema).calculate(exampl); // { name: 'Alexander', phrase: 'Hello Alexander' }
+   * example; // Assigned to sample object { name: 'Alexander', phrase: 'Hello Alexander' };
+   */
+  calculate?: (sample: unknown, mode?: boolean) => unknown;
+  /**
+   * @description Do not use directly - Internal mechanism of type generation
+   */
   toTypescript?: (
     name: string,
     namespace: { definitions: Set<string>; exports: Set<string> },
@@ -132,6 +165,7 @@ class Schema extends ForgePrototype {
   tools: Tools;
   constructor(plan: Plan, options?: Options) {}
   /**
+   * Handyman module required
    * @description Pull subschema from namespace or with field $id;
    * @example
    * schema.pull('MyModule'); // Schema {}


### PR DESCRIPTION
# JSDOC

To have JSDOC comments in your type annotations you need to add <code>\$meta</code> field to your
schema; Also, your <code>\$meta</code> properties should start with <code>@</code>;

## Example

```js
({
  reciever: 'number',
  money: 'number',
  $meta: {
    '@version': 'v1',
    '@name': 'Pay check',
    '@description': 'Cash settlement',
    '@example': '<caption>Check example</caption>\n{ money: 100, reciever: 2 }',
  },
});
```

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
